### PR TITLE
Fix composer dependencies (ukey1-php-sdk:^v3.0.3)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"require": {
 		"php": "^5.5|^7.0",
-		"asaritech/ukey1-php-sdk": "^3.0"
+		"asaritech/ukey1-php-sdk": "^3.0.3"
 	}
 }


### PR DESCRIPTION
Last commit (8ed22ce645c050d8c8d3e025a591e00a316e8e6f) added new feature that requires [ukey1-php-sdk](https://github.com/asaritech/ukey1-php-sdk) at minimal version [v3.0.3](https://github.com/asaritech/ukey1-php-sdk/releases/tag/v3.0.3).

It should be defined in dependency requirements. This PS do it.

BC break: no.