### PR TITLE
Fix request URL parsing

### DIFF
--- a/example/example-logic.php
+++ b/example/example-logic.php
@@ -49,7 +49,9 @@
 	
 	function getUrl($action = null)
 	{
-		$baseUrl = $_SERVER["REQUEST_SCHEME"] . "://" . $_SERVER["HTTP_HOST"] . ":" . $_SERVER["SERVER_PORT"];
+        $scheme = !empty($_SERVER["HTTPS"]) && strcasecmp($_SERVER["HTTPS"], "off") ? "https" : "http";
+        $host = isset($_SERVER["HTTP_HOST"]) ? $_SERVER["HTTP_HOST"] : $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"];
+		$baseUrl = $scheme . "://" . $host;
 		$fullUrl = $baseUrl . $_SERVER["REQUEST_URI"];
 		
 		$parsedUrl = parse_url($fullUrl);


### PR DESCRIPTION
https://github.com/noo-zh/ukey1-php-sdk-example/blob/8ed22ce645c050d8c8d3e025a591e00a316e8e6f/example/example-logic.php#L52

This construct is invalid because:
- `$_SERVER["REQUEST_SCHEME"]` is [not standardised](https://secure.php.net/manual/en/reserved.variables.server.php) and can be not presented,
- `$_SERVER["HTTP_HOST"]` already contains port when non-standard, and can be missing on some SAPI, or when request from browser does not contanins `Host` header.

That results to building invalid URLs with missing scheme, duplicated port nor injected error notice: 
```PHP Notice: Undefined index: REQUEST_SCHEME://localhost:8080:8080/```

This PR is:
- using safely `$_SERVER["HTTPS"]` to detect scheme,
- fixing duplicate port presentation,
- using `$_SERVER["SERVER_NAME"]` as fallback when `$_SERVER["HTTP_HOST"]` missing.